### PR TITLE
Logger script that runs per minute, not second

### DIFF
--- a/tests/data/logger-quiet.CR1X
+++ b/tests/data/logger-quiet.CR1X
@@ -1,0 +1,16 @@
+Public PTemp, Batt_volt
+
+DataTable (Test,1,-1)
+	DataInterval (0,1,Min,10)
+	Sample (1,PTemp,FP2)
+	MQTTPublishTable(1,-1,0,Min,1)
+EndTable
+
+BeginProg
+	Scan (1,Min,0,0)
+		PanelTemp (PTemp,15000)
+		Battery (Batt_volt)
+		CallTable Test
+	NextScan
+EndProg
+


### PR DESCRIPTION
So we don't flood the MQTT logs during testing with the existing script... just changes all the `Sec` options to `Min`