### PR TITLE
Command-line interface for file manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Python Project Template
+# Campbell MQTT Command and Control
 
 [![tests badge](https://github.com/NERC-CEH/campbell-mqtt-control/actions/workflows/pipeline.yml/badge.svg)](https://github.com/NERC-CEH/campbell-mqtt-control/actions)
 [![docs badge](https://img.shields.io/badge/Documentation-blue)](https://nerc-ceh.github.io/campbell-mqtt-control/)

--- a/compose.yml
+++ b/compose.yml
@@ -5,3 +5,4 @@ services:
       - "1883:1883"
     volumes:
       - ./mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
+    restart: unless-stopped

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,6 @@
+topic: 'cs/v2'
+broker: 'AWS'
+serial: 12345
+certificate_pem: 'certificate_filename.pem'
+public_key: 'public_filename.key'
+private_key: 'private_filename.key'

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,8 @@
 topic: 'cs/v2'
 broker: 'AWS'
 serial: 12345
+server: localhost
+port: 1883
 certificate_pem: 'certificate_filename.pem'
 public_key: 'public_filename.key'
 private_key: 'private_filename.key'

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,84 @@
+Command-line interface 
+======================
+
+We provide a command-line interface to the library. You can use this from your PC to update the settings on a remote Campbell device. We plan to provide a way to do this inside Amazon Web Services without having to install the tool or create certificates.
+
+_Note, this document is speculative as it's not implemented yet!
+
+
+Quickstart
+----------
+
+`pip install -e .` - this will install the CLI 
+
+Authentication
+--------------
+
+Create certificates for testing using the AWS console or the `aws` commandline interface.
+
+- `Create AWS IoT client certificates <https://docs.aws.amazon.com/iot/latest/developerguide/device-certs-create.html>`_
+
+Configuration
+-------------
+
+The base `topic` for sending messages and the `broker` client library type will use these defaults if not set out in the JSON format config file:
+
+.. code:: bash
+
+    topic: cs/v2
+    broker: AWS
+
+
+.. code:: javascript
+    
+    { 
+        'topic': 'cs/v2',
+        'broker': 'AWS',
+        'serial': 12345,
+        'certificate-pem': 'certificate_filename.pem',
+        'public-key': 'public_filename.key',
+        'private-key': 'private_filename.key'
+    }
+
+Settings
+--------
+
+All the settings visible through the "Device Configuration Utility" can be read or changed one by one with the `settings` topic.
+*Note: need to infer a canonical list of names for use in the `set` topic, the `Campbell docs <https://help.campbellsci.com/CR300/Content/shared/Communication/mqtt/mqtt-command-control.htm>`_* don't spell them out.
+
+`mqtt-control get [setting]`
+
+Get the value of a specific setting on the logger.
+
+`mqtt-control get --help`
+
+See a list of all the settings available to get or set 
+
+Note: `MQTT settings <https://github.com/NERC-CEH/campbell-mqtt-control/blob/main/src/mqttconfig/README.md>`_ binary format specifically for configuring the MQTT settings all at once.
+
+`mqtt-control set [setting]`
+
+Scripts
+-------
+
+`mqtt-control list` - show a file listing
+`mqtt-control rm` - delete a file
+
+`mqtt-control download --url=[url] --filename=[filename]` - download the file from `url` and save it at the location `filename`. *"If successful, the program will be set to run now and run on power up and the data logger will restart and compile and run the program"*
+
+Script control
+--------------
+
+Optional extras, but nice if quick to implement:
+
+`mqtt-control run filename.crx1` - run a program
+`mqtt-control stop` - stop the currently running program
+
+`mqtt-control getVar` - get the value of a script variable
+`mqtt-control setVar` - set the value of a script variable
+
+TODO
+----
+
+* x.509 certificate rotation, if possible (not clear from the API docs whether it is)
+

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -59,10 +59,10 @@ Note: `MQTT settings <https://github.com/NERC-CEH/campbell-mqtt-control/blob/mai
 Scripts
 -------
 
-`mqtt-control list` - show a file listing
+`mqtt-control ls` - show a file listing
 `mqtt-control rm` - delete a file
 
-`mqtt-control download --url=[url] --filename=[filename]` - download the file from `url` and save it at the location `filename`. *"If successful, the program will be set to run now and run on power up and the data logger will restart and compile and run the program"*
+`mqtt-control put --url=[url] --filename=[filename]` - download the file from `url` and save it at the location `filename`. *"If successful, the program will be set to run now and run on power up and the data logger will restart and compile and run the program"*
 
 Script control
 --------------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -29,16 +29,14 @@ The base `topic` for sending messages and the `broker` client library type will 
     broker: AWS
 
 
-.. code:: javascript
+.. code:: bash
     
-    { 
-        'topic': 'cs/v2',
-        'broker': 'AWS',
-        'serial': 12345,
-        'certificate-pem': 'certificate_filename.pem',
-        'public-key': 'public_filename.key',
-        'private-key': 'private_filename.key'
-    }
+    topic: 'cs/v2'
+    broker: 'AWS'
+    serial: 12345
+    certificate-pem: 'certificate_filename.pem'
+    public-key: 'public_filename.key'
+    private-key: 'private_filename.key'
 
 Settings
 --------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -34,9 +34,9 @@ The base `topic` for sending messages and the `broker` client library type will 
     topic: 'cs/v2'
     broker: 'AWS'
     serial: 12345
-    certificate-pem: 'certificate_filename.pem'
-    public-key: 'public_filename.key'
-    private-key: 'private_filename.key'
+    certificate_pem: 'certificate_filename.pem'
+    public_key: 'public_filename.key'
+    private_key: 'private_filename.key'
 
 Settings
 --------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -38,8 +38,22 @@ The base `topic` for sending messages and the `broker` client library type will 
     public_key: 'public_filename.key'
     private_key: 'private_filename.key'
 
-Settings
---------
+
+Options
+-------
+
+Some options in the configuration file can be over-written by command-line switches.
+
+For example:
+
+`mqtt-control --serial 54321 ls`
+
+Will replace the serial number in the configuration file.
+
+Note that these are options to `mqtt-control` and not to its sub-commands!
+
+Settings (not yet implemented)
+------------------------------
 
 All the settings visible through the "Device Configuration Utility" can be read or changed one by one with the `settings` topic.
 *Note: need to infer a canonical list of names for use in the `set` topic, the `Campbell docs <https://help.campbellsci.com/CR300/Content/shared/Communication/mqtt/mqtt-command-control.htm>`_* don't spell them out.
@@ -60,12 +74,13 @@ Scripts
 -------
 
 `mqtt-control ls` - show a file listing
-`mqtt-control rm` - delete a file
+
+`mqtt-control rm --filename [file]` - delete a file
 
 `mqtt-control put --url=[url] --filename=[filename]` - download the file from `url` and save it at the location `filename`. *"If successful, the program will be set to run now and run on power up and the data logger will restart and compile and run the program"*
 
-Script control
---------------
+Script control (not yet implemented)
+------------------------------------
 
 Optional extras, but nice if quick to implement:
 
@@ -78,5 +93,5 @@ Optional extras, but nice if quick to implement:
 TODO
 ----
 
-* x.509 certificate rotation, if possible (not clear from the API docs whether it is)
+* x.509 certificate rotation, if possible (the `fileControl` interface could be used in an unintended way, but would result in a short downtime while the logger is not running a program)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Campbell Logger Commander
 
    self
    mqtt
+   cli
    mqtt-settings
    sources/modules
    genindex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools >= 70.0", "autosemver"]
 
 [project]
 requires-python = ">=3.12"
-dependencies = ["autosemver", "awscrt", "paho-mqtt", "setuptools", "click", "yaml"]
+dependencies = ["autosemver", "awscrt", "paho-mqtt", "setuptools", "click", "pyyaml"]
 name = "campbell-control"
 dynamic = ["version"]
 description = "A python package for controlling Campbell dataloggers over MQTT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools >= 70.0", "autosemver"]
 
 [project]
 requires-python = ">=3.12"
-dependencies = ["autosemver", "awscrt", "paho-mqtt", "setuptools", "click"]
+dependencies = ["autosemver", "awscrt", "paho-mqtt", "setuptools", "click", "yaml"]
 name = "campbell-control"
 dynamic = ["version"]
 description = "A python package for controlling Campbell dataloggers over MQTT"

--- a/src/campbellcontrol/cli.py
+++ b/src/campbellcontrol/cli.py
@@ -2,20 +2,48 @@ import click
 
 import campbellcontrol.commands.commands as commands
 from campbellcontrol.config import load_config
+from campbellcontrol.connection.aws import AWSConnection
+from campbellcontrol.control import AWSCommandHandler
 
 
-@click.group(context_settings={"auto_envvar_prefix": "FOOP"})  # this allows for environment variables
-@click.option("--config", default="config.yaml", type=click.Path())  # this allows us to change config path
+class CommandContext:
+    """Create one context object that holds a CommandHandler
+    and the rest of the config - click may have a better way!"""
+
+    def __init__(self, config: dict):
+        # TODO - factory for loading the right broker, assume AWS now
+        # https://github.com/NERC-CEH/campbell-mqtt-control/issues/14
+        self.client = AWSConnection("cliclient", config["server"], config["port"])
+        self.command_handler = AWSCommandHandler(self.client)
+        self.config = config
+
+
+@click.group(context_settings={"auto_envvar_prefix": "MQTT"})  # this allows for environment variables
+@click.option("--config", default="config.yaml", type=click.Path())
 @click.pass_context
 def cli(ctx: click.Context, config: str) -> None:
-    # TODO here we need to add context from the config both for the individual Commands,
-    # _and_ context for the command handler (whose class we infer from the broker type passed in the config)
-    ctx.obj = load_config(config)
+    options = load_config(config)
+    ctx.obj = CommandContext(options)
 
 
 @cli.command()
 @click.pass_obj
-def ls(config: dict) -> None:
-    commands.ListFiles(config["topic"], config["serial"], options={"response_suffix": "list"})
+def ls(ctx: CommandContext) -> None:
+    config = ctx.config
+    command = commands.ListFiles(config["topic"], config["serial"], options={"response_suffix": "list"})
     # TODO wire up the command handler properly
-    click.echo(f"ls {config['serial']}")
+    try:
+        response = ctx.command_handler.send_command(command)
+    except ConnectionError as err:
+        click.echo(f"Could not connect to {config['server']}")
+        click.echo(err)
+        return
+
+    if response is None:
+        click.echo(f"Sorry, I couldn't connect to {config['serial']}")
+        return
+
+    if response["success"]:
+        click.echo(f"Files on device {config['serial']}")
+        for f in response["payload"]["fileList"]:
+            click.echo(f)

--- a/src/campbellcontrol/cli.py
+++ b/src/campbellcontrol/cli.py
@@ -67,7 +67,7 @@ def put(ctx: CommandContext, url: str, filename: str) -> None:
 
     # TODO question about pre-signed URLs / token authentication
     try:
-        response = ctx.command_handler.send_command(command, url, "file")
+        response = ctx.command_handler.send_command(command, url, filename)
     except ConnectionError as err:
         click.echo(f"Could not connect to {ctx.server}")
         click.echo(err)
@@ -75,4 +75,5 @@ def put(ctx: CommandContext, url: str, filename: str) -> None:
 
     if response["success"] is False:
         click.echo(f"Failed to upload {url} as {filename}")
-        click.echo(response)
+
+    click.echo(response)

--- a/src/campbellcontrol/cli.py
+++ b/src/campbellcontrol/cli.py
@@ -41,12 +41,12 @@ def ls(ctx: CommandContext) -> None:
     try:
         response = ctx.command_handler.send_command(command)
     except ConnectionError as err:
-        click.echo(f"Could not connect to {ctx.server}")
+        click.echo(f"Sorry, couldn't connect to {ctx.server}")
         click.echo(err)
         return
 
     if response is None:
-        click.echo(f"Sorry, I couldn't connect to {ctx.serial}")
+        click.echo(f"Sorry, couldn't reach {ctx.serial} on {ctx.server}")
         return
 
     if response["success"]:
@@ -64,16 +64,39 @@ def put(ctx: CommandContext, url: str, filename: str) -> None:
 
     if not filename and url:
         click.echo("Please suggest a URL to download the script from and a filename for it")
+        return
 
     # TODO question about pre-signed URLs / token authentication
     try:
         response = ctx.command_handler.send_command(command, url, filename)
     except ConnectionError as err:
-        click.echo(f"Could not connect to {ctx.server}")
+        click.echo(f"Sorry, couldn't connect to {ctx.server}")
         click.echo(err)
         return
 
     if response["success"] is False:
-        click.echo(f"Failed to upload {url} as {filename}")
+        click.echo(f"Couldn't upload {url} as {filename}")
+
+    click.echo(response)
+
+
+@cli.command()
+@click.option("--filename")
+@click.pass_obj
+def rm(ctx: CommandContext, filename: str) -> None:
+    command = commands.DeleteFile(ctx.topic, ctx.serial)
+    if not filename:
+        click.echo("Please suggest the name of a file you want deleting")
+        return
+
+    try:
+        response = ctx.command_handler.send_command(command, filename)
+    except ConnectionError as err:
+        click.echo(f"Sorry, couldn't connect to {ctx.server}")
+        click.echo(err)
+        return
+
+    if response["success"] is False:
+        click.echo(f"Couldn't delete {filename}")
 
     click.echo(response)

--- a/src/campbellcontrol/cli.py
+++ b/src/campbellcontrol/cli.py
@@ -8,42 +8,71 @@ from campbellcontrol.control import AWSCommandHandler
 
 class CommandContext:
     """Create one context object that holds a CommandHandler
-    and the rest of the config - click may have a better way!"""
+    and the rest of the config as attributes - click may have a better way!"""
 
     def __init__(self, config: dict):
         # TODO - factory for loading the right broker, assume AWS now
         # https://github.com/NERC-CEH/campbell-mqtt-control/issues/14
+        # TODO improved error handling
         self.client = AWSConnection("cliclient", config["server"], config["port"])
         self.command_handler = AWSCommandHandler(self.client)
-        self.config = config
+
+        for key, value in config.items():
+            setattr(self, key, value)
 
 
 @click.group(context_settings={"auto_envvar_prefix": "MQTT"})  # this allows for environment variables
 @click.option("--config", default="config.yaml", type=click.Path())
+@click.option("--serial", type=int)
 @click.pass_context
-def cli(ctx: click.Context, config: str) -> None:
+def cli(ctx: click.Context, config: str, serial: int) -> None:
     options = load_config(config)
+    if serial:
+        options["serial"] = serial
     ctx.obj = CommandContext(options)
 
 
 @cli.command()
 @click.pass_obj
 def ls(ctx: CommandContext) -> None:
-    config = ctx.config
-    command = commands.ListFiles(config["topic"], config["serial"], options={"response_suffix": "list"})
-    # TODO wire up the command handler properly
+    """Read and print the list of files on the logger"""
+    command = commands.ListFiles(ctx.topic, ctx.serial, options={"response_suffix": "list"})
+
     try:
         response = ctx.command_handler.send_command(command)
     except ConnectionError as err:
-        click.echo(f"Could not connect to {config['server']}")
+        click.echo(f"Could not connect to {ctx.server}")
         click.echo(err)
         return
 
     if response is None:
-        click.echo(f"Sorry, I couldn't connect to {config['serial']}")
+        click.echo(f"Sorry, I couldn't connect to {ctx.serial}")
         return
 
     if response["success"]:
-        click.echo(f"Files on device {config['serial']}")
+        click.echo(f"Files on device {ctx.serial}")
         for f in response["payload"]["fileList"]:
             click.echo(f)
+
+
+@cli.command()
+@click.option("--url")
+@click.option("--filename")
+@click.pass_obj
+def put(ctx: CommandContext, url: str, filename: str) -> None:
+    command = commands.Program(ctx.topic, ctx.serial)
+
+    if not filename and url:
+        click.echo("Please suggest a URL to download the script from and a filename for it")
+
+    # TODO question about pre-signed URLs / token authentication
+    try:
+        response = ctx.command_handler.send_command(command, url, "file")
+    except ConnectionError as err:
+        click.echo(f"Could not connect to {ctx.server}")
+        click.echo(err)
+        return
+
+    if response["success"] is False:
+        click.echo(f"Failed to upload {url} as {filename}")
+        click.echo(response)

--- a/src/campbellcontrol/cli.py
+++ b/src/campbellcontrol/cli.py
@@ -1,7 +1,21 @@
 import click
 
+from campbellcontrol.config import load_config
 
-@click.command()
+
+# @click.group(context_settings={'auto_envvar_prefix': 'FOOP'})  # this allows for environment variables
+@click.option("--config", default="config.yml", type=click.Path())  # this allows us to change config path
+@click.pass_context
+def mqtt(ctx: click.Context, config: str) -> None:
+    ctx.default_map = load_config(config)
+
+
+@mqtt.command()
+def ls() -> None:
+    click.echo()
+
+
+@mqtt.command()
 def cli() -> None:
     """Prints a greeting."""
     click.echo("Hello, World!")

--- a/src/campbellcontrol/cli.py
+++ b/src/campbellcontrol/cli.py
@@ -1,21 +1,21 @@
 import click
 
+import campbellcontrol.commands.commands as commands
 from campbellcontrol.config import load_config
 
 
-# @click.group(context_settings={'auto_envvar_prefix': 'FOOP'})  # this allows for environment variables
-@click.option("--config", default="config.yml", type=click.Path())  # this allows us to change config path
+@click.group(context_settings={"auto_envvar_prefix": "FOOP"})  # this allows for environment variables
+@click.option("--config", default="config.yaml", type=click.Path())  # this allows us to change config path
 @click.pass_context
-def mqtt(ctx: click.Context, config: str) -> None:
-    ctx.default_map = load_config(config)
+def cli(ctx: click.Context, config: str) -> None:
+    # TODO here we need to add context from the config both for the individual Commands,
+    # _and_ context for the command handler (whose class we infer from the broker type passed in the config)
+    ctx.obj = load_config(config)
 
 
-@mqtt.command()
-def ls() -> None:
-    click.echo()
-
-
-@mqtt.command()
-def cli() -> None:
-    """Prints a greeting."""
-    click.echo("Hello, World!")
+@cli.command()
+@click.pass_obj
+def ls(config: dict) -> None:
+    commands.ListFiles(config["topic"], config["serial"], options={"response_suffix": "list"})
+    # TODO wire up the command handler properly
+    click.echo(f"ls {config['serial']}")

--- a/src/campbellcontrol/commands/commands.py
+++ b/src/campbellcontrol/commands/commands.py
@@ -162,6 +162,7 @@ class Program(Command):
 
         # TODO if there are many of these cases, define the strings separately
         if message.get("fileTransfer", None) == "CRBasic file transfer error":
+            message["error"] = "Program download failed"
             return message
         return None
 

--- a/src/campbellcontrol/commands/commands.py
+++ b/src/campbellcontrol/commands/commands.py
@@ -46,7 +46,11 @@ class Command(ABC):
     """
 
     def __init__(
-        self, group_id: str, serial: str, model: Optional[str] = "cr1000x", options: Optional[dict] = {}
+        self,
+        group_id: str,
+        serial: str,
+        model: Optional[str] = "cr1000x",
+        options: Optional[dict] = {},
     ) -> None:
         """Initializes the class. The topics should match that used by the target logger
 

--- a/src/campbellcontrol/commands/commands.py
+++ b/src/campbellcontrol/commands/commands.py
@@ -159,8 +159,8 @@ class Program(Command):
 
     def handle_state(self, message: dict) -> dict:
         """Accepts the message on a state topic.
-        If it matches very specific events, return it as a response
-        (Used for handling failures, like file download"""
+        If it matches specific message strings, return it as a response
+        """
 
         # TODO if there are many of these cases, define the strings separately
         status = message.get("fileTransfer", None)
@@ -299,6 +299,24 @@ class DeleteFile(Command):
         if drive:
             output.update({"drive": drive})
         return output
+
+    def handle_state(self, message: dict) -> dict:
+        """Accepts the message on a state topic.
+        If it matches specific message strings, return it as a response
+        """
+
+        status = message.get("fileTransfer", None)
+
+        if status == "File Does Not Exist":
+            message["error"] = "File could not be found to delete it"
+            message["success"] = False
+        elif status == "File Has Been Deleted":
+            message["success"] = "File successfully deleted!"
+
+        if "success" in message:
+            return message
+
+        return None
 
 
 class StopProgram(Command):

--- a/src/campbellcontrol/config.py
+++ b/src/campbellcontrol/config.py
@@ -11,6 +11,8 @@ class Config(TypedDict):
     certificate_pem: str
     public_key: str
     private_key: str
+    server: str
+    port: int
 
 
 def load_config(config_file: Optional[str] = "config.yaml") -> dict:

--- a/src/campbellcontrol/config.py
+++ b/src/campbellcontrol/config.py
@@ -1,7 +1,16 @@
 import logging
-from typing import Optional
+from typing import Optional, TypedDict
 
 import yaml
+
+
+class Config(TypedDict):
+    serial: int
+    topic: str
+    broker: str
+    certificate_pem: str
+    public_key: str
+    private_key: str
 
 
 def load_config(config_file: Optional[str] = "config.yaml") -> dict:
@@ -12,4 +21,4 @@ def load_config(config_file: Optional[str] = "config.yaml") -> dict:
         logging.warning(f"Configuration file not found at {config_file}")
         # TODO decide whether to exit or assume defaults, for now:
         raise
-    return config
+    return Config(config)

--- a/src/campbellcontrol/config.py
+++ b/src/campbellcontrol/config.py
@@ -1,0 +1,15 @@
+import logging
+from typing import Optional
+
+import yaml
+
+
+def load_config(config_file: Optional[str] = "config.yaml") -> dict:
+    try:
+        with open(config_file, "r") as conf_file:
+            config = yaml.safe_load(conf_file.read())
+    except (FileNotFoundError, TypeError):
+        logging.warning(f"Configuration file not found at {config_file}")
+        # TODO decide whether to exit or assume defaults, for now:
+        raise
+    return config

--- a/src/campbellcontrol/connection/aws.py
+++ b/src/campbellcontrol/connection/aws.py
@@ -63,7 +63,10 @@ class AWSConnection(Connection):
     def connect(self) -> None:
         """Connect to the MQTT broker."""
         future = self.client.connect()
-        future.result()
+        try:
+            future.result()
+        except AwsCrtError as err:
+            raise ConnectionError(err)
 
     def disconnect(self) -> None:
         """Disconnect from the MQTT broker."""

--- a/src/campbellcontrol/connection/aws.py
+++ b/src/campbellcontrol/connection/aws.py
@@ -89,7 +89,13 @@ class AWSConnection(Connection):
             return
         logger.info("Subscription successful. result: {}".format(result))
 
-    def publish(self, topic: str, payload: str | bytes | bytearray, qos: QoS, retain: bool = False) -> None:
+    def publish(
+        self,
+        topic: str,
+        payload: str | bytes | bytearray,
+        qos: QoS,
+        retain: bool = False,
+    ) -> None:
         """Publish a message to a given topic.
 
         Args:
@@ -114,7 +120,10 @@ class AWSConnection(Connection):
 
     @staticmethod
     def _on_connection_resumed(
-        connection: awscrt.mqtt.Connection, return_code: ConnectReturnCode, session_present: bool, **kwargs
+        connection: awscrt.mqtt.Connection,
+        return_code: ConnectReturnCode,
+        session_present: bool,
+        **kwargs,
     ) -> None:
         """Method called when the connection is resumed.
 

--- a/src/campbellcontrol/control.py
+++ b/src/campbellcontrol/control.py
@@ -135,6 +135,9 @@ class PahoCommandHandler(CommandHandler):
         # Subscribing to response topic
         self.client.subscribe(command.response_topic)
 
+        # Subscribing to state topic
+        self.client.subscribe(command.state_topic)
+
         # Starting listening behaviour
         self.client.client.loop_start()
 
@@ -162,6 +165,8 @@ class AWSCommandHandler(CommandHandler):
             payload: Payload to send.
         """
         self.client.subscribe(command.response_topic, qos=QoS.EXACTLY_ONCE, callback=self.handle_response)
+        self.client.subscribe(command.state_topic, qos=QoS.EXACTLY_ONCE, callback=self.handle_response)
+
         self.client.publish(command.publish_topic, payload, QoS.AT_LEAST_ONCE)
 
     def _terminate_send(self, command: Command) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,18 @@
+import pytest
+from pathlib import Path
+
+
 def pytest_addoption(parser):
     """Configurable default for device serial # when running hardware tests"""
     parser.addoption("--serial", action="store", default="QU8Q-9JTY-HVP8")
     parser.addoption("--server", action="store", default="test.mosquitto.org")
+
+
+@pytest.fixture
+def fixture_dir():
+    return Path(__file__).parent.resolve() / "fixtures"
+
+
+@pytest.fixture
+def config_file(fixture_dir):
+    return fixture_dir / "config.yaml"

--- a/tests/fixtures/config.yaml
+++ b/tests/fixtures/config.yaml
@@ -1,0 +1,6 @@
+topic: 'cs/v2'
+broker: 'AWS'
+serial: 12345
+certificate_pem: 'certificate_filename.pem'
+public_key: 'public_filename.key'
+private_key: 'private_filename.key'

--- a/tests/fixtures/config.yaml
+++ b/tests/fixtures/config.yaml
@@ -1,6 +1,8 @@
 topic: 'cs/v2'
 broker: 'AWS'
 serial: 12345
+server: localhost
+port: 1883
 certificate_pem: 'certificate_filename.pem'
 public_key: 'public_filename.key'
 private_key: 'private_filename.key'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,8 @@
+from click.testing import CliRunner
+from campbellcontrol.cli import cli
+
+def test_cli():
+  runner = CliRunner()
+  result = runner.invoke(cli)
+  assert result.exit_code == 2
+  assert "Show this message and exit" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,9 @@
 from click.testing import CliRunner
 from campbellcontrol.cli import cli
 
+
 def test_cli():
-  runner = CliRunner()
-  result = runner.invoke(cli)
-  assert result.exit_code == 2
-  assert "Show this message and exit" in result.output
+    runner = CliRunner()
+    result = runner.invoke(cli)
+    assert result.exit_code == 2
+    assert "Show this message and exit" in result.output

--- a/tests/test_command_controller.py
+++ b/tests/test_command_controller.py
@@ -77,7 +77,6 @@ class TestPahoCommandHandler(TestCase):
 
         expected = {
             "success": False,
-            "error": "Program download failed",
             "payload": {"error": "Program download failed"},
         }
 

--- a/tests/test_command_controller.py
+++ b/tests/test_command_controller.py
@@ -3,6 +3,7 @@ from campbellcontrol.control import PahoCommandHandler, AWSCommandHandler
 from campbellcontrol.connection.generic import PahoConnection
 from campbellcontrol.connection.aws import AWSConnection
 import campbellcontrol.commands.commands as commands
+import time
 import logging
 import pytest
 
@@ -93,6 +94,18 @@ class TestPahoCommandHandler(TestCase):
         }
 
         self.assertDictEqual(response, expected)
+
+    def test_program_delete(self):
+        command = commands.Program(self.base_topic, self.serial)
+        url = "https://google.com"
+        _ = self.command_handler.send_command(command, url, "test_file")
+        # Give it a wee while to download and reboot - 6 wasn't enough
+        time.sleep(10)
+
+        command = commands.DeleteFile(self.base_topic, self.serial)
+        response = self.command_handler.send_command(command, "test_file")
+
+        self.assertEqual(response["success"], True)
 
     def test_mqttconfig_download_invalid_url(self):
         command = commands.MQTTConfig(self.base_topic, self.serial)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -322,6 +322,13 @@ class TestMQTTCommands(unittest.TestCase):
         )
 
 
+class TestCommand(commands.Command):
+    command_name = "test"
+
+    def payload(self):
+        return {"default": "payload"}
+
+
 class TestHandlers(unittest.TestCase):
     def setUp(self) -> None:
         self.group_id = "loggers/cr6"
@@ -331,7 +338,8 @@ class TestHandlers(unittest.TestCase):
         """Test the base handler payload"""
         payload = b'{"success": "Did a thing"}'
         expected_payload = {"payload": {"success": "Did a thing"}, "success": True}
-        self.assertDictEqual(commands.Command.handler("topic", payload), expected_payload)
+        command = TestCommand("a", "b")
+        self.assertDictEqual(command.handler("topic", payload), expected_payload)
 
     def test_base_handler_error(self):
         """Test the base handler payload"""
@@ -341,13 +349,15 @@ class TestHandlers(unittest.TestCase):
             "success": False,
             "error": "Did the wrong thing",
         }
-        self.assertDictEqual(commands.Command.handler("topic", payload), expected_payload)
+        command = TestCommand("a", "b")
+        self.assertDictEqual(command.handler("topic", payload), expected_payload)
 
     def test_unexpected_payload(self):
         """Test when an unexpected payload is received"""
         payload = b'{"unexpected": "Did something"}'
         expected = None
-        self.assertEqual(commands.Command.handler("topic", payload), expected)
+        command = TestCommand("a", "b")
+        self.assertEqual(command.handler("topic", payload), expected)
 
     def test_list_files_handler(self):
         """Test the list files handler"""

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -352,7 +352,10 @@ class TestHandlers(unittest.TestCase):
     def test_list_files_handler(self):
         """Test the list files handler"""
         payload = b'{"fileList": ["file1", "file2"]}'
-        expected_payload = {"payload": {"fileList": ["file1", "file2"]}, "success": True}
+        expected_payload = {
+            "payload": {"fileList": ["file1", "file2"]},
+            "success": True,
+        }
         self.assertDictEqual(commands.ListFiles.handler("topic", payload), expected_payload)
 
     def test_list_files_handler_error(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,11 @@
+import pytest
+from campbellcontrol.config import load_config, Config
+
+
+def test_config(config_file):
+    conf_data = load_config(config_file)
+    assert "serial" in conf_data
+
+    with pytest.raises(FileNotFoundError):
+        conf_null = load_config("definitely_not_a_file.md")
+        assert "serial" in conf_null


### PR DESCRIPTION
This is the first part of the CLI, which deals with downloading scripts to the logger; making a PR midway because this is already quite a lot of change.

# Contents 

* Adds a `click`-based CLI which is installed as `mqtt-control` during package install
* Adds YAML configuration for it, with sensible defaults and a place for certificates to go
* Adds commands for "ls", "put" and "rm" of logger script files
* Adds documentation for the current and intended state of the CLI
* Adds a `handle_state` function for commands which result in messages on the device state topic, rather than its response topic (hopefully there are not more of these)
* Improves the test coverage a little bit

## What this does

* Shows the CLI and more of the hardware tests running on a real logger
* Enables upload and deletion of scripts via an open MQTT endpoint 

## What this doesn't do yet

* Authentication with the IoT Core endpoint
* Support MQTT brokers other than AWS in the CLI (needs #14) 
* Get/set of logger settings
* Send the logger a new MQTT configuration

 ## To test

It's probably not worth sending this to test until authentication is supported, but if you want to try at this stage:

* Use the Device Configuration tool to add `test.mosquitto.org` endpoint OR run Mosquitto locally with `docker-compose` and point the logger at your IP (this is what I'm doing at home, with the logger plugged into the router) - [documented here](https://nerc-ceh.github.io/campbell-mqtt-control/mqtt.html#running-in-docker). Make sure its base topic is set to `cs/v2`

* Add the server name and device serial number to `config.yaml` here. You can override the serial number with the `--serial` switch
```
serial: 12345
server: localhost
```
Remember it needs python 3.12 or above

```
 pip install -e .
 mqtt-control ls  # shows a file listing
 mqtt-control --serial 54321 put --filename arbitrary_filename --url https://google.com  # uploads the contents of the URL and restarts, trying to run the file as a script
 mqtt-control rm --filename arbitrary_filename  # remove a file from the logger
```

Closes #22 