### PR TITLE
AWS MQTT small fixes

### DIFF
--- a/aws_listener.py
+++ b/aws_listener.py
@@ -34,7 +34,7 @@ def main(client_id: str, server: str, port: int) -> None:
     print("subscribe")
     conn.subscribe(f"{topic}/+/{client_id}", qos=mqtt.QoS.AT_LEAST_ONCE)  # ,callback=on_receive_message)
     conn.subscribe(f"{topic}/+/{client_id}/#", qos=mqtt.QoS.AT_LEAST_ONCE)
-#    conn.subscribe(f"{topic}/#", qos=mqtt.QoS.AT_LEAST_ONCE, callback=on_receive_message)
+    conn.subscribe(f"{topic}/#", qos=mqtt.QoS.AT_LEAST_ONCE, callback=on_receive_message)
 
     receive_event.wait()
 

--- a/src/campbellcontrol/cli.py
+++ b/src/campbellcontrol/cli.py
@@ -9,21 +9,24 @@ from campbellcontrol.config import Config, load_config
 from campbellcontrol.connection.factory import get_command_handler, get_connection
 
 logger = logging.getLogger("campbellcontrol")
-logger.setLevel(logging.WARNING)
+logger.setLevel(logging.INFO)
 
 
 class CommandContext:
     """Create one context object that holds a CommandHandler
     and the rest of the config as attributes - click may have a better way!"""
 
-    def __init__(self, config: Config):
+    def __init__(self, config: Config, device: str=None):
         self.client = get_connection(config)
         self.command_handler = get_command_handler(self.client)
 
         for key, value in dataclasses.asdict(config).items():
             setattr(self, key, value)
-
-
+        if device:
+            self.device = device
+        elif self.client_id:
+            self.device = self.client_id
+        logger.info(self.device)
 class ControlGroup(click.Group):
     def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> Any:
         banner = r"""
@@ -35,20 +38,22 @@ _  _  __  ___ ___    ____ ____ __ _ ___ ____ ____ _
 
 @click.group(cls=ControlGroup, context_settings={"auto_envvar_prefix": "MQTT"})  # this allows for environment variables
 @click.option("--config", default="config.yaml", type=click.Path())
-@click.option("--client_id", type=int)
+@click.option("--client_id", type=str)
+@click.option("--device_id", type=str)
 @click.pass_context
-def cli(ctx: click.Context, config: str, client_id: int) -> None:
+def cli(ctx: click.Context, config: str, client_id: str, device_id: str) -> None:
     options = load_config(config)
     if client_id:
         options.client_id = client_id
-    ctx.obj = CommandContext(options)
+
+    ctx.obj = CommandContext(options, device=device_id)
 
 
 @cli.command()
 @click.pass_obj
 def ls(ctx: CommandContext) -> None:
     """Read and print the list of files on the logger"""
-    command = commands.ListFiles(ctx.topic, ctx.client_id)
+    command = commands.ListFiles(ctx.topic, ctx.device)
 
     try:
         response = ctx.command_handler.send_command(command)
@@ -58,11 +63,11 @@ def ls(ctx: CommandContext) -> None:
         return
 
     if response is None:
-        click.echo(f"Sorry, couldn't reach {ctx.client_id} on {ctx.server}")
+        click.echo(f"Sorry, couldn't reach {ctx.device} on {ctx.server}")
         return
 
     if "success" in response and response["success"]:
-        click.secho(f"\nFiles on device {ctx.client_id}:\n", fg="green")
+        click.secho(f"\nFiles on device {ctx.device}:\n", fg="green")
         for f in response["payload"]["fileList"]:
             click.echo(f)
 
@@ -73,7 +78,7 @@ def ls(ctx: CommandContext) -> None:
 @click.pass_obj
 def put(ctx: CommandContext, url: str, filename: str) -> None:
     """Upload a file at {URL} to a file named {filename} on the logger"""
-    command = commands.Program(ctx.topic, ctx.client_id)
+    command = commands.Program(ctx.topic, ctx.device)
 
     if not filename and url:
         click.echo("Please suggest a URL to download the script from and a filename for it")
@@ -100,7 +105,7 @@ def put(ctx: CommandContext, url: str, filename: str) -> None:
 @click.pass_obj
 def rm(ctx: CommandContext, filename: str) -> None:
     """Delete a named file off the datalogger"""
-    command = commands.DeleteFile(ctx.topic, ctx.client_id)
+    command = commands.DeleteFile(ctx.topic, ctx.device)
     if not filename:
         click.echo("Please suggest the name of a file you want deleting")
         return
@@ -131,7 +136,7 @@ def get(ctx: CommandContext, setting: str) -> None:
 
 def get_setting(ctx: CommandContext, setting: str) -> None:
     """Show an existing setting on the logger"""
-    command = commands.PublishSetting(ctx.topic, ctx.client_id)
+    command = commands.PublishSetting(ctx.topic, ctx.device)
     try:
         response = ctx.command_handler.send_command(command, setting)
     except ConnectionError as err:
@@ -167,7 +172,7 @@ def settings() -> str:
 @click.pass_obj
 def set(ctx: CommandContext, setting: str, value: Union[int, str, float]) -> None:  # noqa: A001
     """Update a setting on the logger"""
-    command = commands.SetSetting(ctx.topic, ctx.client_id)
+    command = commands.SetSetting(ctx.topic, ctx.device)
     try:
         response = ctx.command_handler.send_command(command, setting, value)
     except ConnectionError as err:
@@ -199,7 +204,7 @@ def set(ctx: CommandContext, setting: str, value: Union[int, str, float]) -> Non
 def setvar(ctx: CommandContext, setting: str, value: Union[int, str, float]) -> None:  # noqa: A001
     """Update a script variable on the logger.
     Hopefully useful for adaptive sampling!"""
-    command = commands.SetVar(ctx.topic, ctx.client_id)
+    command = commands.SetVar(ctx.topic, ctx.device)
     try:
         response = ctx.command_handler.send_command(command, setting, value)
     except ConnectionError as err:
@@ -221,7 +226,7 @@ def getvar(ctx: CommandContext, setting: str) -> None:  # noqa: A001
     """Get the value of a script variable on the logger.
     (E.g. anything defined as "Public" in the running script.)
     """
-    command = commands.GetVar(ctx.topic, ctx.client_id)
+    command = commands.GetVar(ctx.topic, ctx.device)
     try:
         response = ctx.command_handler.send_command(command, setting)
     except ConnectionError as err:
@@ -244,8 +249,8 @@ def getvar(ctx: CommandContext, setting: str) -> None:  # noqa: A001
 @click.pass_obj
 def reboot(ctx: CommandContext) -> None:
     """Reboot the logger! Use with caution"""
-    click.confirm(f"Are you sure you want to reboot logger {ctx.client_id}?", abort=True)
-    command = commands.Reboot(ctx.topic, ctx.client_id)
+    click.confirm(f"Are you sure you want to reboot logger {ctx.device}?", abort=True)
+    command = commands.Reboot(ctx.topic, ctx.device)
     try:
         response = ctx.command_handler.send_command(command)
     except ConnectionError as err:
@@ -254,7 +259,7 @@ def reboot(ctx: CommandContext) -> None:
         return
 
     if response is None:
-        click.secho(f"Sorry, couldn't reach {ctx.client_id} on {ctx.server}", fg="yellow")
+        click.secho(f"Sorry, couldn't reach {ctx.device} on {ctx.server}", fg="yellow")
         return
     if "success" in response and response["success"]:
         click.secho(

--- a/src/campbellcontrol/cli.py
+++ b/src/campbellcontrol/cli.py
@@ -16,7 +16,7 @@ class CommandContext:
     """Create one context object that holds a CommandHandler
     and the rest of the config as attributes - click may have a better way!"""
 
-    def __init__(self, config: Config, device: str=None):
+    def __init__(self, config: Config, device: str = None):
         self.client = get_connection(config)
         self.command_handler = get_command_handler(self.client)
 
@@ -27,6 +27,8 @@ class CommandContext:
         elif self.client_id:
             self.device = self.client_id
         logger.info(self.device)
+
+
 class ControlGroup(click.Group):
     def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> Any:
         banner = r"""

--- a/src/campbellcontrol/commands/commands.py
+++ b/src/campbellcontrol/commands/commands.py
@@ -393,9 +393,8 @@ class SetSetting(Command):
         """
         response = {"success": False}
         message = json.loads(message)
-        if "state" in message and message["state"] == "Set Setting Succeeded":
-            response["success"] = True
-            response["payload"] = message
+        if "success" in message:
+            response = message
         return response
 
 

--- a/src/campbellcontrol/connection/aws.py
+++ b/src/campbellcontrol/connection/aws.py
@@ -73,7 +73,6 @@ class AWSConnection(Connection):
         del kwargs["public_key"]
         del kwargs["private_key"]
         del kwargs["certificate_root"]
-
         client = Client(client_bootstrap, tls_context)
         connection = awscrt.mqtt.Connection(
             client,

--- a/src/campbellcontrol/connection/aws.py
+++ b/src/campbellcontrol/connection/aws.py
@@ -60,7 +60,7 @@ class AWSConnection(Connection):
         client_bootstrap = self.get_client_bootstrap()
 
         tls_context = None
-        if kwargs.get("port") == 8883:
+        if self.port == 8883:
             assert kwargs.get("private_key")
             assert kwargs.get("public_key")
 

--- a/src/campbellcontrol/control.py
+++ b/src/campbellcontrol/control.py
@@ -173,7 +173,6 @@ class AWSCommandHandler(CommandHandler):
         self.client.subscribe(command.state_topic, qos=QoS.AT_LEAST_ONCE, callback=self.handle_response)
 
         self.client.publish(command.publish_topic, payload, QoS.AT_LEAST_ONCE)
-        self.receive_event.wait()
 
     def _terminate_send(self, command: Command) -> None:
         """Restores the client to the prior state, unsubscribes from topics.

--- a/tests/data/logger-quiet.CR1X
+++ b/tests/data/logger-quiet.CR1X
@@ -7,7 +7,7 @@ DataTable (Test,1,-1)
 EndTable
 
 BeginProg
-    Scan (1,Min,0,0)
+    Scan (1,Sec,0,0)
         PanelTemp (PTemp,15000)
         Battery (Batt_volt)
         CCTest2 = CCTest


### PR DESCRIPTION
* take out the `receive_wait`, it's only needed for the listener script that keeps the connection open
* option to specify a `device_id` on IoT Core distinct from the `client_id` used when opening the connection (this needs cleaned up)
