### PR TITLE
Remove the model number so our device IDs are consistent

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 topic: 'cs/v2'
 broker: 'AWS'
-serial: 12345
+client_id: 12345
 server: localhost
 port: 1883
 certificate_root: 'CARoot.pem'

--- a/src/campbellcontrol/commands/commands.py
+++ b/src/campbellcontrol/commands/commands.py
@@ -49,17 +49,17 @@ class Command(ABC):
         self,
         group_id: str,
         client_id: str,
-        model: Optional[str] = "cr1000x",
         options: Optional[dict] = {},
     ) -> None:
-        """Initializes the class. The topics should match that used by the target logger
+        """Initializes the class. The topics should match that used by the target logger.
+        Note - if the device is sending "cr1000x/12345" that should be the client ID
 
         Args:
             group_id: The base topic used by the logger.
             client_id: The client identifier (often the serial number) of the target logger
-            model: optional, default 'cr1000x' - the model number of the logger
+
         """
-        self.device_id = f"{model}/{client_id}"
+        self.device_id = client_id
         self.publish_topic = f"{group_id}/cc/{self.device_id}/{self.command_name}"
         self.response_topic = f"{group_id}/cr/{self.device_id}/{self.command_name}"
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,9 +6,8 @@ from campbellcontrol.commands import commands
 class TestMQTTCommands(unittest.TestCase):
     def setUp(self) -> None:
         self.group_id = "loggers/cr6"
-        self.model = "cr1000x"
         self.serial = "ABC#123!"
-        self.device_id = f"{self.model}/{self.serial}"
+        self.device_id = self.serial
 
     def test_os_command(self):
         """Test the OS command."""
@@ -64,19 +63,18 @@ class TestMQTTCommands(unittest.TestCase):
 
     def test_config_device_options(self):
         # can't use pytest.mark.parametrize with unittest classes
-        for model in ["cr6", "cr1000x", "madeup"]:
-            expected_publish_topic = f"{self.group_id}/cc/{model}/{self.serial}/mqttConfig"
-            expected_response_topic = f"{self.group_id}/cr/{model}/{self.serial}/mqttConfig"
-            expected_state_topic = f"{self.group_id}/state/{model}/{self.serial}/"
+        expected_publish_topic = f"{self.group_id}/cc/{self.serial}/mqttConfig"
+        expected_response_topic = f"{self.group_id}/cr/{self.serial}/mqttConfig"
+        expected_state_topic = f"{self.group_id}/state/{self.serial}/"
 
-            command = commands.MQTTConfig(self.group_id, self.serial, model)
+        command = commands.MQTTConfig(self.group_id, self.device_id)
 
-            self.assertEqual(command.publish_topic, expected_publish_topic)
-            self.assertEqual(
-                command.response_topic,
-                expected_response_topic,
-            )
-            self.assertEqual(command.state_topic, expected_state_topic)
+        self.assertEqual(command.publish_topic, expected_publish_topic)
+        self.assertEqual(
+            command.response_topic,
+            expected_response_topic,
+        )
+        self.assertEqual(command.state_topic, expected_state_topic)
 
     def test_edit_constants_command(self):
         """Test the constants editing command."""


### PR DESCRIPTION
* Reverting a change which added a default model number parameter to the topic URL pattern
* The field devices don't have it; the CLI can specify "cr1000x/12345" as device ID
* This can all bear revisiting once we've seen more real-world usage!