### PR TITLE
'apply' no longer optional for set settings

### DIFF
--- a/src/campbellcontrol/cli.py
+++ b/src/campbellcontrol/cli.py
@@ -130,6 +130,7 @@ def rm(ctx: CommandContext, filename: str) -> None:
         click.secho(f"{message}!", fg="green")
 
 
+@cli.command()
 @click.argument("setting")
 @click.pass_obj
 def get(ctx: CommandContext, setting: str) -> None:
@@ -137,7 +138,8 @@ def get(ctx: CommandContext, setting: str) -> None:
 
     To see a list of all settings, type "mqtt-control settings"
     """
-    return get_setting(ctx, setting)
+    setting = get_setting(ctx, setting)
+    click.secho(setting, fg="green")
 
 
 def get_setting(ctx: CommandContext, setting: str) -> None:
@@ -180,7 +182,7 @@ def set(ctx: CommandContext, setting: str, value: Union[int, str, float]) -> Non
     """Update a setting on the logger"""
     command = commands.SetSetting(ctx.topic, ctx.device)
     try:
-        response = ctx.command_handler.send_command(command, setting, value)
+        response = ctx.command_handler.send_command(command, setting, value, apply=True)
     except ConnectionError as err:
         click.echo(f"Sorry, couldn't connect to {ctx.server}")
         click.echo(err)
@@ -192,15 +194,17 @@ def set(ctx: CommandContext, setting: str, value: Union[int, str, float]) -> Non
     # So we should issue a Get to check the value. It comes left padded with spaces
     logging.debug(response)
     message = f"Sorry, couldn't set the {setting} to {value}"
+    color = "yellow"
     if response["success"]:
         new_value = get_setting(ctx, setting)
         try:
             assert str(new_value) == str(value)
             message = f"Happily set the {setting} to {value}!"
+            color = "green"
         except AssertionError as err:
             logging.warning(err)
 
-    click.echo(message)
+    click.secho(message, fg=color)
 
 
 @cli.command()


### PR DESCRIPTION
* Sends the no-longer-optional `apply` parameter when updating settings via MQTT

I think this is a change in behaviour between OS versions. 

The device's "settings" topic sends a success response no matter what value you send it (string types for integer settings, etc) so when the CLI does a `set` it also checks that it's worked by getting the setting value

Prior to upgrading to 8.2.1 this worked without the `apply` parameter in the JSON payload (I don't have a record of exactly which OS version I had before :/), but now it appears that `apply` always needs to be sent for the setting to change.

https://help.campbellsci.com/CR300/Content/shared/Communication/mqtt/mqtt-command-control.htm#set - cf the documentation for `set` here

 


