### PR TITLE
hotfix for NoneType throwing after script reload in some cases

### DIFF
--- a/examples/settings.py
+++ b/examples/settings.py
@@ -42,7 +42,7 @@ if __name__ == '__main__':
         if setting:
             # The value comes back padded with whitespace
             setting = setting.strip()
-            found.append([row['Station Name'], row['ID'], setting])
+            found.append([row['Station Name'], row['UI ID'], setting])
 
     # Export the results as CSV
     with open('out.csv', 'w', newline='') as f:

--- a/src/campbellcontrol/cli.py
+++ b/src/campbellcontrol/cli.py
@@ -99,11 +99,18 @@ def put(ctx: CommandContext, url: str, filename: str) -> None:
         click.echo(err)
         return
 
-    if "error" in response:
-        click.secho(f"Couldn't upload {url} as {filename}", fg="yellow")
-        return
+    message = ''
+    if response:
+        if "error" in response:
+            click.secho(f"Couldn't upload {url} as {filename}", fg="yellow")
+            return
+        elif "success" in response:
+            message = response["payload"]["success"]
 
-    message = response["payload"]["success"]
+    # TODO find out why some devices send a success response, others don't
+    print(response)
+    if not message:
+        message = "The device didn't send a response, but we think this worked. Please double-check with 'mqtt-control ls'"  # noqa: E501
     click.secho(f"{message}!", fg="green")
 
 

--- a/src/campbellcontrol/cli.py
+++ b/src/campbellcontrol/cli.py
@@ -99,7 +99,7 @@ def put(ctx: CommandContext, url: str, filename: str) -> None:
         click.echo(err)
         return
 
-    message = ''
+    message = ""
     if response:
         if "error" in response:
             click.secho(f"Couldn't upload {url} as {filename}", fg="yellow")
@@ -110,7 +110,9 @@ def put(ctx: CommandContext, url: str, filename: str) -> None:
     # TODO find out why some devices send a success response, others don't
     print(response)
     if not message:
-        message = "The device didn't send a response, but we think this worked. Please double-check with 'mqtt-control ls'"  # noqa: E501
+        message = (
+            "The device didn't send a response, but we think this worked. Please double-check with 'mqtt-control ls'"  # noqa: E501
+        )
     click.secho(f"{message}!", fg="green")
 
 

--- a/src/campbellcontrol/commands/commands.py
+++ b/src/campbellcontrol/commands/commands.py
@@ -131,23 +131,22 @@ class Program(Command):
     The downloaded file is set to the current program and reboots the logger.
 
     If the download fails, the response is sent on `state`, we see two messages.
-    This varies according to Campbell firmware version.
-        {"clientId": "ABC",
-          "state": "offline",
-          "reason": "Loading program"}
-        { "clientId": "ABC",
-          "state": "online",
-          "fileTransfer": "Program file download"}
-
-        {"clientId":"ABC",
-         "state":"online",
-         "fileTransfer":"CRBasic file transfer started"}
-
-        {"clientId":"ABC",
-         "state":"online",
-         "fileTransfer":"CRBasic file transfer error"}
-
+    This may vary according to Campbell firmware version.
     """
+    #{"clientId": "ABC",
+    #  "state": "offline",
+    #  "reason": "Loading program"}
+    #{ "clientId": "ABC",
+    #  "state": "online",
+    #  "fileTransfer": "Program file download"}
+
+    #{"clientId":"ABC",
+    # "state":"online",
+    # "fileTransfer":"CRBasic file transfer started"}
+
+    #{"clientId":"ABC",
+    # "state":"online",
+    # "fileTransfer":"CRBasic file transfer error"}
 
     command_name = "program"
 

--- a/src/campbellcontrol/commands/commands.py
+++ b/src/campbellcontrol/commands/commands.py
@@ -130,7 +130,14 @@ class Program(Command):
     """Command to download a CRBasic Program.
     The downloaded file is set to the current program and reboots the logger.
 
-    If the download fails, the response is sent on `state`, we see two messages:
+    If the download fails, the response is sent on `state`, we see two messages.
+    This varies according to Campbell firmware version.
+        {"clientId": "ABC",
+          "state": "offline",
+          "reason": "Loading program"}
+        { "clientId": "ABC",
+          "state": "online",
+          "fileTransfer": "Program file download"}
 
         {"clientId":"ABC",
          "state":"online",
@@ -167,7 +174,7 @@ class Program(Command):
         if status == "CRBasic file transfer error":
             message["error"] = "Program download failed"
             message["success"] = False
-        elif status == "Loading CRBasic file":
+        elif status == "Loading CRBasic file" or status == "Loading program":
             message["success"] = "Program loaded successfully"
 
         if "success" in message:

--- a/src/campbellcontrol/connection/aws.py
+++ b/src/campbellcontrol/connection/aws.py
@@ -17,7 +17,7 @@ from awscrt.mqtt import (
 
 from campbellcontrol.connection.interface import Connection
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This is more of a workaround than a true fix, and also not possible to test without access to two Campbell dataloggers running different firmware versions.

I think what we're seeing is that the response comes back on a topic we're not expecting it on. The existing code was masking the problem by sending the user the same success message as the eventual (post-reboot) success response when it sees the new script being applied.

It worked as-was but threw a nasty NoneType error in the event there wasn't a response to read. I'm not 100% clear why this behaved differently and need to look at the message logs with fresh eyes. This "fixes" the problem by instead of throwing, waiting for the timeout, and letting the user know that no news is probably good news but to please check that.

Please see the linked issue at #46 for diagnostics